### PR TITLE
style : MyCalender의 Minical,Bigcal 컴포넌트 아래로 조정

### DIFF
--- a/SSARY_Front/src/views/MyCalendarView.vue
+++ b/SSARY_Front/src/views/MyCalendarView.vue
@@ -40,6 +40,15 @@ import TodoList from "@/components/todo/TodoList.vue";
   height: 100%;
 }
 
+.mini-calendar-container,
+.big-calendar-container {
+  margin-top: 2rem; /* 아래로 간격 설정 */
+}
+
+.additional-container {
+  margin-top: 2rem; /* 동일한 간격 유지 */
+}
+
 .mini-calendar-container {
   flex: 1;
   max-width: 16.66%; /* 작은 캘린더는 전체 너비의 1/6 */


### PR DESCRIPTION
## 📔 어떤 기능인가요? 
- MyCalender에 있는 Minical과 Bigcal 컴포넌트의 위치를 CalenderView에 있는 컴포넌트 위치와 동일하게 수정하였습니다. 

## 📔  작업 상세 내용 
```
.mini-calendar-container,
.big-calendar-container {
  margin-top: 2rem; /* 아래로 간격 설정 */
}

.additional-container {
  margin-top: 2rem; /* 동일한 간격 유지 */
}
```
두 컴포넌트를 감싸고 있는 컨테이너의 위쪽 마진값을 주어 헤더와 간격을 두었습니다. 

## ✏️ 참고 자료 (선택)
