### PR TITLE
style 수정사항

### DIFF
--- a/SSARY_Front/src/components/calendar/Bigcal.vue
+++ b/SSARY_Front/src/components/calendar/Bigcal.vue
@@ -252,7 +252,6 @@ onMounted(() => {
 
 .date-cell {
   min-height: 8rem;
-  max-height: 8rem; /* 고정 높이 설정 */
   border: 1px solid var(--neutral-light);
   padding: 0.2rem;
   background-color: var(--background-color);

--- a/SSARY_Front/src/views/MyCalendarView.vue
+++ b/SSARY_Front/src/views/MyCalendarView.vue
@@ -43,10 +43,20 @@ import TodoList from "@/components/todo/TodoList.vue";
 .mini-calendar-container {
   flex: 1;
   max-width: 16.66%; /* 작은 캘린더는 전체 너비의 1/6 */
+  min-width: 12rem; /* 고정 최소 너비 (192px) */
 }
 
 .big-calendar-container {
   flex: 4; /* 큰 캘린더는 전체 너비의 4/6 */
+}
+
+.mini-calendar-container,
+.big-calendar-container {
+  margin-top: 2rem; /* 아래로 간격 설정 */
+}
+
+.additional-container {
+  margin-top: 2rem; /* 동일한 간격 유지 */
 }
 .additional-container {
   flex: 1;


### PR DESCRIPTION
## 📔  어떤 기능인가요? 
- 이전에 수정했으나 적용되지 않아 다시 MyCalenderView에 있는 Bigcal과 Minical 컴포넌트의 위치를 아래로 수정했습니다. 
- Bigcal 컴포넌트를 화면 축소시 date-cell 사이의 공백이 생기는 문제를 해결했습니다. 


## 📔 작업 상세 내용 
![image](https://github.com/user-attachments/assets/1ddebda9-6d23-45d6-b026-90a02f82e4e7)
Bigcal의 date-cell의 max-height 최대 높이 설정을 제거함으로써 화면 깨짐을 보완하였습니다. 




![image](https://github.com/user-attachments/assets/dfcd7cf2-7222-43cf-9b26-32844b6f01a7)
1. MyCalenderView에서 Minical 컴포넌트의 최소 가로 값을 설정하여 미니 캘린더가 깨지지 않도록 하였습니다. 
2.  이전에 적용하였던 내용이지만 두개의 컴포넌트들이 헤더와 겹쳐 보이는 현상을 margin-top기능을 이용해 간격을 두어 해결하였습니다. 


## ✏️ 참고자료(선택) 


